### PR TITLE
Fix character range to include last character

### DIFF
--- a/src/range.js
+++ b/src/range.js
@@ -50,7 +50,7 @@ Range.prototype.getRandom = function () {
 		let min = this._minCharCode;
 		let max = this._maxCharCode;
 
-		return String.fromCharCode((max - min) * Math.random() + min);
+		return String.fromCharCode((max + 1 - min) * Math.random() + min);
 	}
 };
 


### PR DESCRIPTION
Currently, character ranges generate up to but don't include the "max" character specified.

```
const deity = require('./dist/deity.min');
deity('repeat:4:(char:A-C)', str => {
    console.log(str);
});
```

Results in strings containing only 'A' and 'B'.
